### PR TITLE
Updated to support bytecode format

### DIFF
--- a/iree/jax/iree.py
+++ b/iree/jax/iree.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 from typing import Dict, List
 from .program_api import Program
 
@@ -70,11 +71,11 @@ class IREE:
   def compiled_artifact(self):
     if not self._compiled_artifact:
       ir_module = Program.get_mlir_module(self._program)
-      ir_module_serialized = ir_module.operation.get_asm(
-          binary=True, assume_verified=True)
-
+      output = io.BytesIO()
+      ir_module.operation.write_bytecode(file=output)
+      bytecode = output.getvalue()
       self._compiled_artifact = iree.compiler.tools.compile_str(
-          ir_module_serialized, target_backends=self._backends, input_type="mhlo")
+        bytecode, target_backends=self._backends, input_type="mhlo")
 
     return self._compiled_artifact
 

--- a/iree/jax/program_api.py
+++ b/iree/jax/program_api.py
@@ -18,6 +18,7 @@ It interfaces with the lower level exporter.
 """
 
 import inspect
+import io
 import logging
 import re
 from typing import Any, Callable, Dict, Generator, Optional, Tuple, Union
@@ -375,6 +376,10 @@ class Program(metaclass=ProgramMeta):
   def get_mlir_module(m: ProgramClassOrInstance) -> ir.Module:
     info = Program.get_info(Program._get_instance(m))
     return info.export_module.module
+
+  def save(m: ProgramClassOrInstance, o: io.BufferedIOBase):
+    ir_module = Program.get_mlir_module(m)
+    ir_module.operation.write_bytecode(file=o)
 
   @staticmethod
   def export_global(captured_value: Any,


### PR DESCRIPTION
This includes both compiling the bytecode file instead of serializing to IR,
and a new method function for saving the bytecode out.