### PR TITLE
Make tests accept both generic and custom form ml_program

### DIFF
--- a/iree/jax/ir_utils.py
+++ b/iree/jax/ir_utils.py
@@ -27,6 +27,7 @@ def create_context(*, debug: bool = True) -> ir.Context:
   context = ir.Context()
   if debug:
     context.enable_multithreading(False)
+  context.allow_unregistered_dialects = True
   chlo_d.register_chlo_dialect(context)
   mhlo_d.register_mhlo_dialect(context)
   return context

--- a/tests/program/trivial_globals.py
+++ b/tests/program/trivial_globals.py
@@ -45,13 +45,26 @@ class TrivialGlobals(Program):
 instance = TrivialGlobals()
 
 # CHECK-LABEL: module @trivial_globals
-# CHECK: ml_program.global private mutable @_params$0(dense<0.000000e+00> : tensor<3x4xf32>)
-# CHECK: ml_program.global private mutable @_params$1(dense<0.000000e+00> : tensor<3x4xf32>)
+# CHECK: ml_program.global
+# CHECK-SAME: _params$0
+# CHECK-SAME: dense<0.000000e+00> : tensor<3x4xf32>
+# CHECK: ml_program.global
+# CHECK-SAME: _params$1
+# CHECK-SAME: dense<0.000000e+00> : tensor<3x4xf32>
 # CHECK: func @get_params() -> (tensor<3x4xf32>, tensor<3x4xf32>)
-# CHECK:   %0 = ml_program.global_load @_params$0 : tensor<3x4xf32>
-# CHECK:   %1 = ml_program.global_load @_params$1 : tensor<3x4xf32>
+# CHECK:   %0 =
+# CHECK-SAME: ml_program.global_load
+# CHECK-SAME: _params$0
+# CHECK:   %1 =
+# CHECK-SAME: ml_program.global_load
+# CHECK-SAME: _params$1
 # CHECK:   return %0, %1
 # CHECK: func @set_params(%arg0: tensor<3x4xf32>, %arg1: tensor<3x4xf32>)
-# CHECK:   ml_program.global_store @_params$0 = %arg0 : tensor<3x4xf32>
-# CHECK:   ml_program.global_store @_params$1 = %arg1 : tensor<3x4xf32>
+# CHECK:   ml_program.global_store
+# CHECK-SAME-DAG: _params$0
+# CHECK-SAME-DAG: %arg0
+# CHECK:   ml_program.global_store
+# CHECK-SAME-DAG: _params$1
+# CHECK-SAME-DAG: %arg1
 print(Program.get_mlir_module(instance))
+


### PR DESCRIPTION
- Update to use new nightly URL (#33)
- Enable unregistered dialects temporarily
- Make tests accept both generic and custom form ml_program
