### PR TITLE
Make the example in README.md runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ write comments and explanations.
 # Everything that is needed for basic use can be accessed from the Program
 # class. Some additional imports may be needed for more advanced cases.
 from iree.jax import Program
+import jax.numpy as jnp
+from collections import namedtuple
 
 # Host-side arrays and trees of arrays can be mirrored into an IREE Program.
 # All structure and any aliasing between trees is retained in the program.


### PR DESCRIPTION
After adding these two lines, I could copy-n-paste this example into a Python source file, say `/tmp/a.py`, and run it.

```
18:01 $ python /tmp/a.py
module @trivial_kernel {
  "ml_program.global"() {is_mutable, sym_name = "_params$0", sym_visibility = "private", type = tensor<3x4xf32>, value = dense<4.000000e+00> : tensor<3x4xf32>} : () -> ()
  "ml_program.global"() {is_mutable, sym_name = "_params$1", sym_visibility = "private", type = tensor<3x4xf32>, value = dense<1.000000e+00> : tensor<3x4xf32>} : () -> ()
  func.func @get_params() -> (tensor<3x4xf32>, tensor<3x4xf32>) {
    %0 = "ml_program.global_load"() {global = @_params$0} : () -> tensor<3x4xf32>
    %1 = "ml_program.global_load"() {global = @_params$1} : () -> tensor<3x4xf32>
    return %0, %1 : tensor<3x4xf32>, tensor<3x4xf32>
  }
  func.func @run(%arg0: tensor<3x4xf32>) -> tensor<3x4xf32> {
    %0 = "ml_program.global_load"() {global = @_params$0} : () -> tensor<3x4xf32>
    %1 = "ml_program.global_load"() {global = @_params$1} : () -> tensor<3x4xf32>
    %2 = call @jit__linear$main(%arg0, %0, %1) : (tensor<3x4xf32>, tensor<3x4xf32>, tensor<3x4xf32>) -> tensor<3x4xf32>
    "ml_program.global_store"(%2) {global = @_params$0} : (tensor<3x4xf32>) -> ()
    return %2 : tensor<3x4xf32>
  }
  func.func private @jit__linear$main(%arg0: tensor<3x4xf32> {mhlo.sharding = ""}, %arg1: tensor<3x4xf32> {mhlo.sharding = ""}, %arg2: tensor<3x4xf32> {mhlo.sharding = ""}) -> tensor<3x4xf32> {
    %0 = stablehlo.multiply %arg0, %arg1 : tensor<3x4xf32>
    %1 = stablehlo.add %0, %arg2 : tensor<3x4xf32>
    return %1 : tensor<3x4xf32>
  }
  func.func @set_params(%arg0: tensor<3x4xf32>, %arg1: tensor<3x4xf32>) {
    "ml_program.global_store"(%arg0) {global = @_params$0} : (tensor<3x4xf32>) -> ()
    "ml_program.global_store"(%arg1) {global = @_params$1} : (tensor<3x4xf32>) -> ()
    return
  }
}

Traceback (most recent call last):
  File "/tmp/a.py", line 95, in <module>
    print("Initial params:", m.get_params())
  File "/Users/y/w/iree-jax/iree/jax/program_api.py", line 284, in _uncallable_public_export
    raise RuntimeError(f"Calls to exported functions not yet supported")
RuntimeError: Calls to exported functions not yet supported
```