### PR TITLE
Fix tests and bumping scrips

### DIFF
--- a/.github/workflows/test_gpt2_model.yaml
+++ b/.github/workflows/test_gpt2_model.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install Python Dependencies
         run: |
-          python3 -m pip install absl-py future h5py numpy transformers
+          python3 -m pip install absl-py future h5py numpy optax transformers
 
       - name: Run installation
         run: |

--- a/.github/workflows/test_head_and_bump.yaml
+++ b/.github/workflows/test_head_and_bump.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Run IREE-JAX Installation
         run: |
           python $GITHUB_WORKSPACE/build_tools/configure.py
-          python3 -m pip install . -f https://iree-org.github.io/iree/pip-release-links.html --force-reinstall .[xla,cpu,test]
+          python3 -m pip install . -f https://openxla.github.io/iree/pip-release-links.html --force-reinstall .[xla,cpu,test]
 
       - name: Run Tests
         run: |

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ pure Python and can be installed locally for development (note that this
 pulls from IREE pre-release snapshots):
 
 ```shell
-python -m pip install -e .[test,xla,cpu] -f https://iree-org.github.io/iree/pip-release-links.html
+python -m pip install -e .[test,xla,cpu] -f https://openxla.github.io/iree/pip-release-links.html
 ```
 
 Note that in order to function the version of MLIR and MHLO used in the

--- a/models/gpt2/config.py
+++ b/models/gpt2/config.py
@@ -18,4 +18,4 @@ flags.DEFINE_string('assets_path', assets_dir, 'Path for assets dir')
 # T - decode step size
 def get_config():
     config = collections.namedtuple('Config', ['B', 'K', 'S', 'T'])
-    return config(1, 8, 64, 1)
+    return config(4, 8, 64, 1)

--- a/models/gpt2/example_finetune.py
+++ b/models/gpt2/example_finetune.py
@@ -14,7 +14,7 @@ assert_dir = os.path.join(sys.path[0], "assets")
 params = model.load_gpt2_model("gpt2", assert_dir)
 
 cfg = config.get_config()
-B = cfg.B  # Batch size
+B = 1      # Batch size
 K = cfg.K  # Input sequence length
 S = cfg.S  # completed text length
 T = cfg.T  # Batched decode

--- a/models/gpt2/example_generate.py
+++ b/models/gpt2/example_generate.py
@@ -12,7 +12,8 @@ import model
 import config
 
 cfg = config.get_config()
-B = cfg.B  # Batch size
+
+B = 1  # Batch size
 K = cfg.K  # Input sequence length
 S = cfg.S
 T = cfg.T  # Batched decode


### PR DESCRIPTION
The default configuration was changed to had a batch size of 1. This breaks the export tests as it
requires atleast a batch size of two. Changed to default batch size of 4 and added custom configuration
for tests that required batch size of 1.

Also includes fixes for pip install locations and tests.