### PR TITLE
Added a notification of the gpt-2 test to discord notifications

### DIFF
--- a/.github/workflows/release_wheel.yaml
+++ b/.github/workflows/release_wheel.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   build_sdist:
     name: Build source distribution
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e #v2
         with:

--- a/.github/workflows/test_gpt2_model.yaml
+++ b/.github/workflows/test_gpt2_model.yaml
@@ -38,3 +38,12 @@ jobs:
       - name: Test GPT-2
         run: |
           python $GITHUB_WORKSPACE/models/gpt2/test_export.py
+
+      - name: Posting to Discord
+        uses: sarisia/actions-status-discord@c193626e5ce172002b8161e116aa897de7ab5383 # v1.10.2
+        if: ${{ failure() }}
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "iree-jax gpt2 regressions tests failed"
+          color: 0x0000ff
+          username: GitHub Actions

--- a/.github/workflows/test_gpt2_model.yaml
+++ b/.github/workflows/test_gpt2_model.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   install_test:
     name: Install latest iree-jax release and tests GPT-2
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e #v2

--- a/.github/workflows/test_presubmit.yaml
+++ b/.github/workflows/test_presubmit.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   install_test:
     name: Install and Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2


### PR DESCRIPTION
The discord notification to the gpt-2 test so that failures will
appear in the appropriate chat. This is the most strenuous test of
our iree-jax integration libraries and should be used as a general
smoketest.