### PR TITLE
Add -C - option to curl when downloading

### DIFF
--- a/models/gpt2/setup.sh
+++ b/models/gpt2/setup.sh
@@ -2,7 +2,7 @@
 
 cd "$(dirname "$0")"
 mkdir -p assets
-curl -L https://huggingface.co/gpt2/raw/main/vocab.json -o assets/vocab.json
-curl -L https://huggingface.co/gpt2/raw/main/tokenizer.json -o assets/tokenizer.json
-curl -L https://huggingface.co/gpt2/raw/main/merges.txt -o assets/merges.txt
-curl -L https://huggingface.co/gpt2/resolve/main/tf_model.h5 -o assets/tf_model.h5
+curl -C - -L https://huggingface.co/gpt2/raw/main/vocab.json -o assets/vocab.json
+curl -C - -L https://huggingface.co/gpt2/raw/main/tokenizer.json -o assets/tokenizer.json
+curl -C - -L https://huggingface.co/gpt2/raw/main/merges.txt -o assets/merges.txt
+curl -C - -L https://huggingface.co/gpt2/resolve/main/tf_model.h5 -o assets/tf_model.h5


### PR DESCRIPTION
Every time I run setup.sh, it downloads everything from the beginning.

Adding `-C -` to curl makes curl try to continue the downloading. If the file has been there, curl will return quickly.