### PR TITLE
Make config.py confgurable from the command-line

### DIFF
--- a/models/gpt2/config.py
+++ b/models/gpt2/config.py
@@ -10,6 +10,13 @@ assets_dir = path.join(pathlib.Path(__file__).parent.resolve(), "assets")
 flags.DEFINE_string('binary_path', '/tmp/gpt2.vmfb', 'Path for binary')
 flags.DEFINE_string('ir_path', '/tmp/gpt2.mlir', 'Path for IR')
 flags.DEFINE_string('assets_path', assets_dir, 'Path for assets dir')
+flags.DEFINE_boolean('no_compile', False, 'Generate MLIR only, no IREE compling.')
+
+
+flags.DEFINE_integer('batch_size', 4, 'Minibatch size', lower_bound=1)
+flags.DEFINE_integer('encoder_sequence_length', 8, 'Encoder sequence length', lower_bound=1)
+flags.DEFINE_integer('total_sequence_length', 64, 'Total sequence length', lower_bound=1)
+flags.DEFINE_integer('decode_step_size', 1, 'Decode step size', lower_bound=1)
 
 # Create a tuple with model configuration details as follows:
 # B - batch size
@@ -18,4 +25,5 @@ flags.DEFINE_string('assets_path', assets_dir, 'Path for assets dir')
 # T - decode step size
 def get_config():
     config = collections.namedtuple('Config', ['B', 'K', 'S', 'T'])
-    return config(4, 8, 64, 1)
+    FLAGS = flags.FLAGS
+    return config(FLAGS.batch_size, FLAGS.encoder_sequence_length, FLAGS.total_sequence_length, FLAGS.decode_step_size)

--- a/models/gpt2/config.py
+++ b/models/gpt2/config.py
@@ -1,4 +1,4 @@
-'''Flags and model configuration details, useful for replicating across files.'''
+"""Flags and model configuration details, useful for replicating across files."""
 from absl import flags
 from os import path
 
@@ -7,16 +7,21 @@ import pathlib
 
 assets_dir = path.join(pathlib.Path(__file__).parent.resolve(), "assets")
 
-flags.DEFINE_string('binary_path', '/tmp/gpt2.vmfb', 'Path for binary')
-flags.DEFINE_string('ir_path', '/tmp/gpt2.mlir', 'Path for IR')
-flags.DEFINE_string('assets_path', assets_dir, 'Path for assets dir')
-flags.DEFINE_boolean('no_compile', False, 'Generate MLIR only, no IREE compling.')
+flags.DEFINE_string("binary_path", "/tmp/gpt2.vmfb", "Path for binary")
+flags.DEFINE_string("ir_path", "/tmp/gpt2.mlir", "Path for IR")
+flags.DEFINE_string("assets_path", assets_dir, "Path for assets dir")
+flags.DEFINE_boolean("no_compile", False, "Generate MLIR only, no IREE compling.")
 
 
-flags.DEFINE_integer('batch_size', 4, 'Minibatch size', lower_bound=1)
-flags.DEFINE_integer('encoder_sequence_length', 8, 'Encoder sequence length', lower_bound=1)
-flags.DEFINE_integer('total_sequence_length', 64, 'Total sequence length', lower_bound=1)
-flags.DEFINE_integer('decode_step_size', 1, 'Decode step size', lower_bound=1)
+flags.DEFINE_integer("batch_size", 4, "Minibatch size", lower_bound=1)
+flags.DEFINE_integer(
+    "encoder_sequence_length", 8, "Encoder sequence length", lower_bound=1
+)
+flags.DEFINE_integer(
+    "total_sequence_length", 64, "Total sequence length", lower_bound=1
+)
+flags.DEFINE_integer("decode_step_size", 1, "Decode step size", lower_bound=1)
+
 
 # Create a tuple with model configuration details as follows:
 # B - batch size
@@ -24,6 +29,11 @@ flags.DEFINE_integer('decode_step_size', 1, 'Decode step size', lower_bound=1)
 # S - total sequence length
 # T - decode step size
 def get_config():
-    config = collections.namedtuple('Config', ['B', 'K', 'S', 'T'])
+    config = collections.namedtuple("Config", ["B", "K", "S", "T"])
     FLAGS = flags.FLAGS
-    return config(FLAGS.batch_size, FLAGS.encoder_sequence_length, FLAGS.total_sequence_length, FLAGS.decode_step_size)
+    return config(
+        FLAGS.batch_size,
+        FLAGS.encoder_sequence_length,
+        FLAGS.total_sequence_length,
+        FLAGS.decode_step_size,
+    )

--- a/models/gpt2/export.py
+++ b/models/gpt2/export.py
@@ -105,7 +105,8 @@ def main(argv):
   with open(FLAGS.ir_path, 'w') as f:
     f.write(str(Program.get_mlir_module(module)))
 
-  compiler.compile_file(
+  if not FLAGS.no_compile:
+    compiler.compile_file(
       FLAGS.ir_path,
       input_type="mhlo",
       output_file=FLAGS.binary_path,


### PR DESCRIPTION
The goal of this pull request is to (1) preserve the present CI as is, and (2) allow users to export an MHLO for on-device inference and fine-tuning, which requires `batch_size == 1`.

I confirmed that I can execute the following commands to generate the MHLO file and build it into Metal GPU kernels.


```bash
python models/gpt2/export.py --batch_size=1 --no_compile

iree-compile \
  --iree-input-type=mhlo \
  --iree-hal-target-backends=metal \
  --iree-metal-compile-to-metallib=false \
  /tmp/gpt2.mlir \
  -o /tmp/gpt2-metal.vmfb
```

The command `iree-compile` was built from the feature branch https://github.com/antiagainst/iree/tree/apple-metal-hal.