### PR TITLE
Add support for passing `ShapeDtypeStruct` to `iree.jax.like`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.venv
 .env
 *.egg-info/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ pure Python and can be installed locally for development (note that this
 pulls from IREE pre-release snapshots):
 
 ```shell
-python -m pip install -e .[test,xla,cpu] -f https://openxla.github.io/iree/pip-release-links.html
+python -m pip install -e '.[test,xla,cpu]' -f https://openxla.github.io/iree/pip-release-links.html
 ```
 
 Note that in order to function the version of MLIR and MHLO used in the

--- a/iree/jax/jax_utils.py
+++ b/iree/jax/jax_utils.py
@@ -28,7 +28,7 @@ import jax.numpy as jnp
 # Need to interop with the JAX version of MLIR, which may or may not be
 # what we have here.
 from jax._src.lib.mlir import ir as jax_ir
-from jax.interpreters.xla import abstractify as jax_abstractify
+from jax._src.api_util import shaped_abstractify
 
 _JAX_CONTEXT = jax_ir.Context()
 _JAX_LOC = jax_ir.Location.unknown(context=_JAX_CONTEXT)
@@ -59,7 +59,7 @@ def abstractify(x) -> jax.core.AbstractValue:
   # Note that a ConcreteArray is an AbstractValue so we handle that above.
   if isinstance(x, jax.core.AbstractValue):
     return x
-  return jax_abstractify(x)
+  return shaped_abstractify(x)
 
 
 def unwrap_global_array(x) -> Optional[array_types.ExportedGlobalArray]:

--- a/tests/program/trivial_kernel.py
+++ b/tests/program/trivial_kernel.py
@@ -25,6 +25,7 @@ from iree.jax import kernel, like, Program, IREE
 
 logging.basicConfig(level=logging.DEBUG)
 
+multiplier = jax.ShapeDtypeStruct((3, 4), jnp.float32)
 x = jnp.ones((3, 4), jnp.float32) * 4.0
 b = jnp.ones((3, 4), jnp.float32)
 
@@ -43,7 +44,7 @@ class TrivialKernel(Program):
   def get_params(self):
     return self._params
 
-  def run(self, multiplier=like(x)):
+  def run(self, multiplier=like(multiplier)):
     result = self._linear(multiplier, self._params.x, self._params.b)
     self._x = result
     return result
@@ -63,7 +64,7 @@ print(Program.get_mlir_module(m))
 b = IREE.compile_program(m, backends=["vmvx"])
 
 print("Initial params:", [a.to_host() for a in b.get_params()])
-update = np.asarray(jnp.ones_like(x))
+update = np.asarray(jnp.ones(multiplier.shape, multiplier.dtype))
 print("Run:", b.run(update).to_host())
 print("Run:", b.run(update + 2.0).to_host())
 print("Updated params:", [a.to_host() for a in b.get_params()])


### PR DESCRIPTION
Allows users to pass `jax.ShapeDtypeStruct`s to `iree.jax.like`. This is useful in frameworks like PAX, which use `jax.ShapeDtypeStruct`s to document input specifications.