### PR TITLE
Remove reference to `IREE_BUILD_LEGACY_JAX`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,9 +254,6 @@ directory:
 source .env && export PYTHONPATH
 ```
 
-You must have built IREE with the `-DIREE_BUILD_LEGACY_JAX=OFF` to disable
-the original bundled JAX API.
-
 You may need to pip uninstall the automatically installed
 `iree-compiler-snapshot` and `iree-runtime-snapshot` packages.
 


### PR DESCRIPTION
The legacy JAX API was deleted from IREE in https://github.com/openxla/iree/pull/8031, so the `IREE_BUILD_LEGACY_JAX` option no longer exists.

Thanks to https://github.com/iree-org/iree-jax/issues/70 for pointing this out, the README could probably use other updates.