### PR TITLE
Use stable URL for IREE pip-release-links.

### DIFF
--- a/build_tools/pip_install.py
+++ b/build_tools/pip_install.py
@@ -25,7 +25,7 @@ def main():
   iree_version = pinned_versions["iree-compiler"]
   print(iree_version)
 
-  command = f"python3 -m pip install . -f https://openxla.github.io/iree/pip-release-links.html --force-reinstall .[xla,cpu,test]"
+  command = f"python3 -m pip install . -f https://iree.dev/pip-release-links.html --force-reinstall .[xla,cpu,test]"
   print(command)
   proc = subprocess.Popen(command.split(' '))
   _, err = proc.communicate()


### PR DESCRIPTION
The `openxla.github.io` link depends on a specific GitHub organization, and the IREE repo will be moving soon (multiple times). The `iree.dev` release links URL is recommended here: https://iree.dev/reference/bindings/python/#prebuilt-packages